### PR TITLE
Add cix.embed define to force enable embed

### DIFF
--- a/src/cix/css/Runtime.hx
+++ b/src/cix/css/Runtime.hx
@@ -1,6 +1,6 @@
 package cix.css;
 
-#if (js && !nodejs)
+#if (cix.embed || (js && !nodejs))
 class Runtime {
   static var indices:Map<String, Int>;
   


### PR DESCRIPTION
This is mainly for electron apps where both html/css and nodejs are available.